### PR TITLE
Fix related fields filter (pre- Django 4.x)

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2117,9 +2117,12 @@ class BaseModelResource(Resource):
         if not filter_bits:
             # No filter type to resolve, use default
             return default_filter_type
-        elif filter_bits[0] not in self.get_query_terms(field_name):
+
+        if filter_bits[0] not in self.get_query_terms(field_name):
             # Not valid, maybe related field, use default
-            return self.resolve_filter_type(field_name=filter_bits[0], filter_bits=filter_bits[1:])
+            related_resource = self.fields[field_name].get_related_resource(None)
+
+            return related_resource.resolve_filter_type(field_name=filter_bits[0], filter_bits=filter_bits[1:])
         else:
             # A valid filter type
             return filter_bits[0]

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2092,7 +2092,11 @@ class BaseModelResource(Resource):
             if related_resource is None:
                 return default_filter_type
 
-            return related_resource.resolve_filter_type(field_name=filter_bits[0], filter_bits=filter_bits[1:])
+            return related_resource.resolve_filter_type(
+                field_name=filter_bits[0],
+                filter_bits=filter_bits[1:],
+                default_filter_type=default_filter_type,
+            )
         else:
             # A valid filter type
             return filter_bits[0]

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2089,6 +2089,9 @@ class BaseModelResource(Resource):
             # Not valid, maybe related field, use default
             related_resource = self.fields[field_name].get_related_resource(None)
 
+            if related_resource is None:
+                return default_filter_type
+
             return related_resource.resolve_filter_type(field_name=filter_bits[0], filter_bits=filter_bits[1:])
         else:
             # A valid filter type

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2086,12 +2086,14 @@ class BaseModelResource(Resource):
             return default_filter_type
 
         if filter_bits[0] not in self.get_query_terms(field_name):
-            # Not valid, maybe related field, use default
+            # Not valid, maybe related field
             related_resource = self.fields[field_name].get_related_resource(None)
 
             if related_resource is None:
+                # the field is not a related resource, use default
                 return default_filter_type
 
+            # recursively perform the same operation on a related resource
             return related_resource.resolve_filter_type(
                 field_name=filter_bits[0],
                 filter_bits=filter_bits[1:],

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2019,7 +2019,7 @@ class BaseModelResource(Resource):
             # Only a field provided, match with provided filter type
             return [self.fields[field_name].attribute] + [filter_type]
 
-        elif len(filter_bits) == 1 and filter_bits[0] in self.get_query_terms(field_name, filter_bits):
+        elif len(filter_bits) == 1 and filter_bits[0] in self.get_query_terms(field_name):
             # Match with valid filter type (i.e. contains, startswith, Etc.)
             return [self.fields[field_name].attribute] + filter_bits
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2062,39 +2062,6 @@ class BaseModelResource(Resource):
 
         return value
 
-    def get_final_destination(self, field_name, filter_bits):
-        # Nothing to traverse anymore
-        if filter_bits is None or len(filter_bits) == 0:
-            django_field_name = self.fields[field_name].attribute
-            django_field = self._meta.object_class._meta.get_field(django_field_name)
-
-            if hasattr(django_field, 'field'):
-                django_field = django_field.field  # related field
-
-            return django_field
-
-        try:
-            # We still have something to traverse, so check if it is realted reousrce
-            related_resource = self.fields[field_name].get_related_resource(None)
-
-            if related_resource is not None:
-                next_field_name = filter_bits[0]
-                next_chain = filter_bits[1:]
-
-                return related_resource.get_final_destination(field_name=next_field_name, filter_bits=next_chain)
-
-            else:
-                django_field_name = self.fields[field_name].attribute
-                django_field = self._meta.object_class._meta.get_field(django_field_name)
-
-                if hasattr(django_field, 'field'):
-                    django_field = django_field.field  # related field
-
-                return django_field
-
-        except FieldDoesNotExist:
-            raise InvalidFilterError("The '%s' field is not a valid field name" % field_name)
-
     def get_query_terms(self, field_name):
         """ Helper to determine supported filter operations for a field """
 


### PR DESCRIPTION
Fixes the issue with using the filters on nested related resources, like `post__author__in` or `post__author__name__startswith`, where requests were failing to return the expected result

See the corresponding comment on the original set of changes here: https://github.com/django-tastypie/django-tastypie/pull/1619/files#r921042385