### PR TITLE
Combine the fixes for related fields filtering from two fork repositories (for Django 4.x, PROD-3315)

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1998,7 +1998,7 @@ class BaseModelResource(Resource):
             raise InvalidFilterError("The '%s' field does not allow filtering." % field_name)
 
         # Check to see if it's an allowed lookup type.
-        if self._meta.filtering[field_name] not in (ALL, ALL_WITH_RELATIONS):
+        if filter_type != 'exact' and self._meta.filtering[field_name] not in (ALL, ALL_WITH_RELATIONS):
             # Must be an explicit whitelist.
             if filter_type not in self._meta.filtering[field_name]:
                 raise InvalidFilterError("'%s' is not an allowed filter on the '%s' field." % (filter_type, field_name))
@@ -2007,7 +2007,16 @@ class BaseModelResource(Resource):
             raise InvalidFilterError("The '%s' field has no 'attribute' for searching with." % field_name)
 
         # Check to see if it's a relational lookup and if that's allowed.
-        if len(filter_bits):
+        if len(filter_bits) == 0:
+            # Only a field provided, match with provided filter type
+            return [self.fields[field_name].attribute] + [filter_type]
+
+        elif len(filter_bits) == 1 and filter_bits[0] in self.get_query_terms(field_name):
+            # Match with valid filter type (i.e. contains, startswith, Etc.)
+            return [self.fields[field_name].attribute] + filter_bits
+
+        else:
+            # Check to see if it's a relational lookup and if that's allowed.
             if not getattr(self.fields[field_name], 'is_related', False):
                 raise InvalidFilterError("The '%s' field does not support relations." % field_name)
 
@@ -2018,9 +2027,12 @@ class BaseModelResource(Resource):
             # if any. We should ensure that all along the way, we're allowed
             # to filter on that field by the related resource.
             related_resource = self.fields[field_name].get_related_resource(None)
-            return [self.fields[field_name].attribute] + related_resource.check_filtering(filter_bits[0], filter_type, filter_bits[1:])
 
-        return [self.fields[field_name].attribute]
+            next_field_name = filter_bits[0]
+            next_filter_bits = filter_bits[1:]
+            next_filter_type = related_resource.resolve_filter_type(next_field_name, next_filter_bits, filter_type)
+
+            return [self.fields[field_name].attribute] + related_resource.check_filtering(next_field_name, next_filter_type, next_filter_bits)
 
     def filter_value_to_python(self, value, field_name, filters, filter_expr,
             filter_type):
@@ -2041,6 +2053,46 @@ class BaseModelResource(Resource):
                 value = value.split(',')
 
         return value
+
+    def get_query_terms(self, field_name):
+        """ Helper to determine supported filter operations for a field """
+
+        if field_name not in self.fields:
+            raise InvalidFilterError("The '%s' field is not a valid field" % field_name)
+
+        try:
+            django_field_name = self.fields[field_name].attribute
+            django_field = self._meta.object_class._meta.get_field(django_field_name)
+            if hasattr(django_field, 'field'):
+                django_field = django_field.field  # related field
+        except FieldDoesNotExist:
+            raise InvalidFilterError("The '%s' field is not a valid field name" % field_name)
+
+        return django_field.get_lookups().keys()
+
+    def resolve_filter_type(self, field_name, filter_bits, default_filter_type=None):
+        """ Helper to derive filter type from next segment in filter bits """
+
+        if not filter_bits:
+            # No filter type to resolve, use default
+            return default_filter_type
+        if filter_bits[0] not in self.get_query_terms(field_name):
+            # Not valid, maybe related field
+            related_resource = self.fields[field_name].get_related_resource(None)
+
+            if related_resource is None:
+                # the field is not a related resource, use default
+                return default_filter_type
+
+            # recursively perform the same operation on a related resource
+            return related_resource.resolve_filter_type(
+                field_name=filter_bits[0],
+                filter_bits=filter_bits[1:],
+                default_filter_type=default_filter_type,
+            )
+        else:
+            # A valid filter type
+            return filter_bits[0]
 
     def build_filters(self, filters=None, ignore_bad_filters=False):
         """
@@ -2069,26 +2121,13 @@ class BaseModelResource(Resource):
         for filter_expr, value in filters.items():
             filter_bits = filter_expr.split(LOOKUP_SEP)
             field_name = filter_bits.pop(0)
-            filter_type = 'exact'
 
             if field_name not in self.fields:
                 # It's not a field we know about. Move along citizen.
                 continue
 
-            # Validate filter types other than 'exact' that are supported by the field type
             try:
-                django_field_name = self.fields[field_name].attribute
-                django_field = self._meta.object_class._meta.get_field(django_field_name)
-                if hasattr(django_field, 'field'):
-                    django_field = django_field.field  # related field
-            except FieldDoesNotExist:
-                raise InvalidFilterError("The '%s' field is not a valid field name" % field_name)
-
-            query_terms = django_field.get_lookups().keys()
-            if len(filter_bits) and filter_bits[-1] in query_terms:
-                filter_type = filter_bits.pop()
-
-            try:
+                filter_type = self.resolve_filter_type(field_name, filter_bits, 'exact')
                 lookup_bits = self.check_filtering(field_name, filter_type, filter_bits)
             except InvalidFilterError:
                 if ignore_bad_filters:
@@ -2097,8 +2136,7 @@ class BaseModelResource(Resource):
                     raise
             value = self.filter_value_to_python(value, field_name, filters, filter_expr, filter_type)
 
-            db_field_name = LOOKUP_SEP.join(lookup_bits)
-            qs_filter = "%s%s%s" % (db_field_name, LOOKUP_SEP, filter_type)
+            qs_filter = LOOKUP_SEP.join(lookup_bits)
             qs_filters[qs_filter] = value
 
         return qs_filters

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1131,7 +1131,7 @@ class DetailedNoteResource(ModelResource):
             'content': ['startswith', 'exact'],
             'title': ALL,
             'slug': ['exact'],
-            'user': ALL,
+            'user': ALL_WITH_RELATIONS,
             'hello_world': ['exact'],  # Note this is invalid for filtering.
         }
         ordering = ['title', 'slug', 'user']
@@ -2183,7 +2183,7 @@ class ModelResourceTestCase(TestCase):
 
         # Check where the field name doesn't match the database relation.
         resource_4 = AnotherSubjectResource()
-        self.assertEqual(resource_4.build_filters(filters={'notes__user__startswith': 'Daniel'}), {'notes__author__startswith': 'Daniel'})
+        self.assertEqual(resource_4.build_filters(filters={'notes__user__username__startswith': 'Daniel'}), {'notes__author__username__startswith': 'Daniel'})
 
         # Make sure build_filters works even on resources without queryset
         resource = NoQuerysetNoteResource()
@@ -2196,6 +2196,9 @@ class ModelResourceTestCase(TestCase):
         resource = AnotherSubjectResource()
         # Make sure that fields that don't have attributes can't be filtered on.
         self.assertRaises(InvalidFilterError, resource.build_filters, filters={'notes__hello_world': 'News'})
+
+        # Make sure that fields that don't have related attributes can't be filtered on.
+        self.assertRaises(InvalidFilterError, resource.build_filters, filters={'notes__content__contains': 'News'})
 
     def test_custom_build_filters(self):
         """


### PR DESCRIPTION
This branch in build on top of the latest version of the `master` branch, which was synced with the original Tastypie repository on Apr 10, 2023. This was an important prerequisite for the upgrade to Django 4.x (PROD-3315)

Combines the fixes from two repositories:
1. https://github.com/django-tastypie/django-tastypie/pull/1619 (doesn't look like this PR will ever be merged, but it provides useful fixes crucial for the operation of old Partender API endpoints)
2. https://github.com/Partender/django-tastypie/pull/1 - useful addition to the same branch (the missing fix in the original solution)

(essentially, this is a cherry-pick of https://github.com/dizlv/django-tastypie/commit/2fb3f07299c7568b91e2507d191f059dd6205725 now added to this repository)